### PR TITLE
Allow comments to appear on the first line of a `table` or `enum`

### DIFF
--- a/fbs-parser/src/lexer.rs
+++ b/fbs-parser/src/lexer.rs
@@ -184,7 +184,7 @@ peg::parser! {
             = [' ']* ":" [' ']* s:single_value() { s }
 
         rule field() -> Field
-            = i:ident() [' ']* ":" [' ']* t:type_ident() l:field0()? m:field1()? semi_eol() __ {
+            = (comment() __)? i:ident() [' ']* ":" [' ']* t:type_ident() l:field0()? m:field1()? semi_eol() __ {
                 Field {
                     name: i,
                     ty: t,


### PR DESCRIPTION
This was considered invalid before and is now accepted

```
table Foo {
    /// comment
    bar: Baz;
}
```